### PR TITLE
Upload wormhole binaries only once within the build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,11 @@
 language: go
 go:
 - 1.8.x
-- 1.x
+- 1.9.x
+matrix:
+  include:
+    go: '1.9.x'
+    env: BUILD_UPLOAD=true
 install: make setup
 sudo: required
 services:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,10 @@
 language: go
-go:
-- 1.8.x
-- 1.9.x
 matrix:
   include:
-    go: '1.9.x'
-    env: BUILD_UPLOAD=true
+    - go: '1.8.x'
+      env: BUILD_UPLOAD=false
+    - go: '1.9.x'
+      env: BUILD_UPLOAD=true
 install: make setup
 sudo: required
 services:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 * Complies with breaking ssh behavior changes introduced in https://github.com/golang/go/issues/19767
 * Fully migrated testing/building/releasing to Travis CI
 * Bug with unhandled error in TLS wrappers
+* Bug in build script that caused binaries to be uploaded for each Go version (#22)
 
 ## [0.5.35] - 2017-06-15
 ### Added

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -29,8 +29,12 @@ elif [ -z "$TRAVIS_TAG" ] && [ "$TRAVIS_BRANCH" == "master" ]; then
   CHANNEL=beta
   VERSION=$MAJOR.$MINOR.$PATCH
 else
-  echo "Not building a tag, nothing to do."
-  exit 0
+  MAJOR=0
+  MINOR=0
+  PATCH=0-alpha.${TRAVIS_COMMIT:0:7}
+  CHANNEL=alpha
+  VERSION=$MAJOR.$MINOR.$PATCH
+  BUILD_UPLOAD=false
 fi
 
 # download glide if it's not available
@@ -83,7 +87,7 @@ if [ $num_binaries -lt 9 ]; then
   exit 1
 fi
 
-if [ -z "$BUILD_UPLOAD" ]; then
+if [ -z "$BUILD_UPLOAD" ] || [ "$BUILD_UPLOAD" == "false" ]; then
   echo "BUILD_UPLOAD is not set. Not going to upload binaries."
   exit 0
 fi

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -34,7 +34,7 @@ else
   PATCH=0-alpha.${TRAVIS_COMMIT:0:7}
   CHANNEL=alpha
   VERSION=$MAJOR.$MINOR.$PATCH
-  BUILD_UPLOAD=false
+  BUILD_UPLOAD=${BUILD_UPLOAD:-false}
 fi
 
 # download glide if it's not available

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -22,7 +22,7 @@ if [ -n "$TRAVIS_TAG" ]; then
     CHANNEL=beta
     VERSION=$MAJOR.$MINOR.$PATCH
   fi
-elif [ -z "$TRAVIS_TAG" ] && [ "$TRAVIS_BRANCH" = "master" ]; then
+elif [ -z "$TRAVIS_TAG" ] && [ "$TRAVIS_BRANCH" == "master" ]; then
   MAJOR=0
   MINOR=0
   PATCH=0-beta.${TRAVIS_COMMIT:0:7}
@@ -83,7 +83,12 @@ if [ $num_binaries -lt 9 ]; then
   exit 1
 fi
 
-if [ "$CHANNEL" = "stable" ]; then
+if [ -z "$BUILD_UPLOAD" ]; then
+  echo "BUILD_UPLOAD is not set. Not going to upload binaries."
+  exit 0
+fi
+
+if [ "$CHANNEL" == "stable" ]; then
   GHR='./github-release'
 
   if [ ! -f $GHR ]; then
@@ -95,7 +100,7 @@ if [ "$CHANNEL" = "stable" ]; then
     chmod +x $GHR
   fi
 
-  echo " Creating GitHub release"
+  echo "Creating GitHub release"
 
   $GHR $TRAVIS_TAG pkg/* --commit $TRAVIS_COMMIT \
                             --tag $TRAVIS_TAG \
@@ -122,7 +127,7 @@ base_image_name="flyio/wormhole"
 # ensure we have the binary before building an image
 wormhole_linux_bin=pkg/wormhole_linux_amd64
 if [ ! -f "$wormhole_linux_bin" ]; then
-  echo "missing wormhole binary in $wormhole_linux_bin"
+  echo "Missing wormhole binary in $wormhole_linux_bin"
   exit 1
 fi
 
@@ -132,9 +137,9 @@ docker build -t $base_image_name .
 # clean up
 rm -f ./app
 
-if [ "$CHANNEL" = "stable" ]; then
+if [ "$CHANNEL" == "stable" ]; then
   tag_versions=("${MAJOR}" "${MAJOR}.${MINOR}" "${MAJOR}.${MINOR}.${PATCH}" "$CHANNEL")
-elif [ "$CHANNEL" = "beta" ] && [ "$TRAVIS_BRANCH" = "master" ]; then
+elif [ "$CHANNEL" == "beta" ] && [ "$TRAVIS_BRANCH" = "master" ]; then
   tag_versions=("${VERSION}" "${CHANNEL}")
 else
   tag_versions=("$VERSION")


### PR DESCRIPTION
## Pull Request Checklist

**Is this in reference to an existing issue?**

Yes, #22 

#### General

- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [x] Update README with any necessary configuration snippets

- [x] Existing tests pass

#### Purpose

We don't want to override wormhole binaries compiled with older Go version. We do want to support a number of Go versions (within reason), but we want to release with the latest stable one if possible.
