### PR TITLE
Conn pool rewrite

### DIFF
--- a/remote/http2_handler_test.go
+++ b/remote/http2_handler_test.go
@@ -70,7 +70,7 @@ func TestMain(m *testing.M) {
 
 	if err := pool.Retry(func() error {
 		var err error
-		c, err := redis.DialURL(fmt.Sprintf("redis://localhost:%s", redisResource.GetPort("6379/tcp")))
+		c, err := redis.DialURL(fmt.Sprintf("redis://127.0.0.1:%s", redisResource.GetPort("6379/tcp")))
 		if err != nil {
 			return err
 		}

--- a/session/http2_session_test.go
+++ b/session/http2_session_test.go
@@ -69,7 +69,7 @@ func TestMain(m *testing.M) {
 
 	if err := pool.Retry(func() error {
 		var err error
-		c, err := redis.DialURL(fmt.Sprintf("redis://localhost:%s", redisResource.GetPort("6379/tcp")))
+		c, err := redis.DialURL(fmt.Sprintf("redis://127.0.0.1:%s", redisResource.GetPort("6379/tcp")))
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
## Pull Request Checklist

**Is this in reference to an existing issue?**
No
TODO: Some test improvement should happen before merging with the min-max-heap
#### General

- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [x] Update README with any necessary configuration snippets

- [x] Existing tests pass

#### Purpose

Tldr; remove the round-robin style load balancing in favor of a 2-structure min-max-heap(active load balancing) and no-use channel hybrid load balancer.

This PR drastically reduces complexity and increases flexibility for the `ConnPool` abstraction. First we add the option for `ConnPoolObject`s to implement an additional interface, a `ConnPoolObjectCanMux-` which indicates that the connection object is able to have muxed activity over itself. The `ConnPoolObjectCanMux` requires an extra method `Value() <-chan int` where before insertion it should already have a value queued. The value is used in organizing a min-max-heap which self-adjusts based on load value information reported from the `ConnPoolObjectCanMux`

We have 2 main methods now for delivering a connection from a call to `Get()`. The first is from a `noActivityConnCh` which will be queued with any connection which is either muxable or non-muxable and is not distributed outside the `ConnPool`. This allows for synchronization when all we have in the pool are non-muxable conns, it also gives us a slight retrieval latency reduction when we are in low-load conditions and we have muxable conns which are currently not servicing any requests (pulling off a pre-populated channel is slightly faster than pulling from a min-max-heap). If no conns are in `noActivityConnCh` and we have no conns in the min-max-heap then we block until either a new conn is added to the pool or a non-muxable conn is freed from use outside the pool. If no conns are in the `noActivityConnCh` and there are conns available in the min-max-heap we pull the conn which is reporting the lowest load value and return it.

As a side-note this could allow us in the future to store multiple connection types in a single ConnPool per session - thus laying the way for multiple connection types in a given session