### PR TITLE
allow tls on local endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 ### Added
 
+* Can now connect to local endpoints via TLS
+
 ### Fixed
 * Race condition with session access in remote/http2 (#26)
 * Errant `FLY_ENDPOINT` references in usage output

--- a/local.go
+++ b/local.go
@@ -33,7 +33,10 @@ func StartLocal(cfg *config.ClientConfig) {
 
 	switch cfg.Protocol {
 	case config.SSH:
-		handler = local.NewSSHHandler(cfg, release)
+		handler, err = local.NewSSHHandler(cfg, release)
+		if err != nil {
+			log.Fatal(err)
+		}
 	case config.TCP:
 		handler, err = local.NewTCPHandler(cfg, release)
 		if err != nil {

--- a/local/http2_handler_test.go
+++ b/local/http2_handler_test.go
@@ -97,17 +97,17 @@ func TestNewHTTP2Handler(t *testing.T) {
 	assert.NoError(t, err, "Should be no error creating new handler")
 
 	controlHandler := &HTTP2Handler{
-		RemoteEndpoint: testRemoteListener.Addr().String(),
-		FlyToken:       "test_token",
-		Version:        "test_version",
-		LocalEndpoint:  httpTestServer.Listener.Addr().String(),
-		tlsConfig:      testTLSClientConfig,
+		RemoteEndpoint:  testRemoteListener.Addr().String(),
+		FlyToken:        "test_token",
+		Version:         "test_version",
+		LocalEndpoint:   httpTestServer.Listener.Addr().String(),
+		remoteTLSConfig: testTLSClientConfig,
 	}
 
 	assert.Equal(t, expHandler.RemoteEndpoint, controlHandler.RemoteEndpoint, "Remote endpoints should match")
 	assert.Equal(t, expHandler.LocalEndpoint, controlHandler.LocalEndpoint, "Local endpoints should match")
 	assert.Equal(t, expHandler.Version, controlHandler.Version, "Versions should match")
-	assert.EqualValues(t, expHandler.tlsConfig, controlHandler.tlsConfig, "TLS Configs should match")
+	assert.EqualValues(t, expHandler.remoteTLSConfig, controlHandler.remoteTLSConfig, "TLS Configs should match")
 }
 
 func newTestHTTP2Handler() (*HTTP2Handler, error) {

--- a/scripts/wormhole-local.sh
+++ b/scripts/wormhole-local.sh
@@ -21,17 +21,19 @@ dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 # wormhole client defaults
 export FLY_PROTO=ssh
+export FLY_LOCAL_ENDPOINT_USE_TLS=1
+export FLY_LOCAL_ENDPOINT_INSECURE_SKIP_VERIFY=1
 export FLY_LOG_LEVEL=debug
-export FLY_REMOTE_ENDPOINT=localhost:10000
+export FLY_REMOTE_ENDPOINT=127.0.0.1:10000
 export FLY_TLS_CERT_FILE=$dir/cert.pem
 
 
 LOCAL_SERVER_CMD=\
 "go run $GOPATH/src/github.com/valyala/fasthttp/examples/fileserver/fileserver.go"\
-" -addrTLS localhost:$TLS_PORT"\
+" -addrTLS 127.0.0.1:$TLS_PORT"\
 " -certFile=$dir/cert.pem"\
 " -keyFile=$dir/key.pem"\
-" -addr localhost:$PORT"\
+" -addr 127.0.0.1:$PORT"\
 " -dir $dir"
 
 echo "LOCAL CMD: $LOCAL_SERVER_CMD"
@@ -48,7 +50,7 @@ register_client() {
 spawn_wormhole() {
   token=$1
 
-  FLY_TOKEN=$token FLY_PORT=$PORT $GOPATH/src/github.com/superfly/wormhole/bin/wormhole &
+  FLY_TOKEN=$token FLY_PORT=$TLS_PORT $GOPATH/src/github.com/superfly/wormhole/bin/wormhole &
   CHILD_PIDS+=("$!")
   echo "DONE (PID: $!)"
 }

--- a/scripts/wormhole-server.sh
+++ b/scripts/wormhole-server.sh
@@ -18,9 +18,9 @@ fi
 
 export FLY_PROTO=ssh
 export FLY_LOG_LEVEL=debug
-export FLY_REDIS_URL=redis://localhost:6379
-export FLY_CLUSTER_URL=localhost
-export FLY_LOCALHOST=localhost
+export FLY_REDIS_URL=redis://127.0.0.1:6379
+export FLY_CLUSTER_URL=127.0.0.1
+export FLY_LOCALHOST=127.0.0.1
 export FLY_TLS_CERT_FILE=$GOPATH/src/github.com/superfly/wormhole/scripts/cert.pem
 export FLY_TLS_PRIVATE_KEY_FILE=$GOPATH/src/github.com/superfly/wormhole/scripts/key.pem
 


### PR DESCRIPTION
This commit allows TLS to work on local endpoints. It also removes
ambiguity in what particular connection words mean. INTER prefixes
before envvars means the value is referring to a connection between
wh-server <-> wh-client. While LOCAL_ENDPOINT prefixes refer to
connections between wh-client <-> local endpoint.

## Pull Request Checklist

**Is this in reference to an existing issue?**
Yes, implements https://github.com/superfly/wormhole/issues/31
#### General

Implements TLS for connecting to local endpoints. Also, removes ambiguity in connection naming schemes for arguments and configs

- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [x] Update README with any necessary configuration snippets

- [x] Existing tests pass

#### Purpose
